### PR TITLE
feature(activate): Clicking on a notification will open in terminal

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ var OSXReporter = function(helper, logger) {
       message = util.format('%d tests passed in %s.', results.success, time);
     }
 
-    var uri = '/' + str_request + "?title=" + encodeURIComponent(title) + "&message=" + encodeURIComponent(message);
+    var uri = '/' + str_request + "?title=" + encodeURIComponent(title) + "&message=" + encodeURIComponent(message) + "&activate=" + encodeURIComponent('com.apple.Terminal');
     var options = {
       host: config_osx.host,
       port: config_osx.port,


### PR DESCRIPTION
Assuming that tests are run from terminal, it will be useful to quickly switch to terminal to see results. This is especially helpful if you work in full screen mode, or your tests failed and you need to review them. 

This capability is outlined here: https://github.com/azoff/node-osx-notifier
